### PR TITLE
Improve test output

### DIFF
--- a/run/test
+++ b/run/test
@@ -141,8 +141,13 @@ testFrontend()
 	export MASTER_PID=$$
 	export PORT=${PORT:-"4000"}
 
+	APPLOG="app.log"
+
 	# Launch API service in the background
-	node out/start.js &
+	echo "Starting app in the background"
+	script /dev/null \
+		--quiet --command "node out/start.js" \
+		< /dev/null > ${APPLOG} 2>&1 &
 
 	# Grab PID of background process
 	NODE_PID=$!
@@ -167,8 +172,10 @@ testFrontend()
 
 	runNightwatch "test/nightwatch-frontend.js" "Frontend"
 
-	echo "Terminating Node process ${NODE_PID}"
+	echo "Terminating background process ${NODE_PID}"
 	kill ${NODE_PID}
+
+	echo -e "Check \033[38;1m${APPLOG}\033[0m for app output"
 }
 
 ### Execute all test suites

--- a/test/nightwatch-frontend.js
+++ b/test/nightwatch-frontend.js
@@ -1,15 +1,12 @@
-const {
-	log,
-	openPage,
-} = require('./test-tools-frontend');
+const { openPage } = require('./test-tools-frontend');
 
 const chromedriver = require('chromedriver');
 const geckodriver = require('geckodriver');
 const seleniumJAR = require('selenium-server-standalone-jar');
 
-log('Selenium version: %s', seleniumJAR.version);
-log('Chrome driver version: %s', chromedriver.version);
-log('Gecko driver version: %s', geckodriver.version);
+console.log('Selenium version:', seleniumJAR.version);
+console.log('Chrome driver version:', chromedriver.version);
+console.log('Gecko driver version:', geckodriver.version);
 
 // require('source-map-support/register');  -- not quite there yet
 // require('ts-node/register');


### PR DESCRIPTION
Redirect app output to a log file while running in the background of the frontend tests