### PR TITLE
BasicPersistingService.clear() should drop collection indexes

### DIFF
--- a/src/app/db/common/index.ts
+++ b/src/app/db/common/index.ts
@@ -34,7 +34,9 @@ export { wrapSave } from './wrapSave';
 
 export function clearCollection <T extends Document> (model : Model <T>) : Promise <void> {
 	if (isTest) {
-		return model.remove({}).then(() => undefined);
+		return model.remove({})
+		.then(() => model.collection.dropIndexes())
+		.then(() => undefined);
 	}
 	throw new Error('Function can only be used in TEST mode');
 }


### PR DESCRIPTION
Solves [RC-118](https://dbmedialab.atlassian.net/browse/RC-118)