### PR TITLE
Generic object populate in FeedbackService

### DIFF
--- a/src/app/services/feedback/FeedbackDAO.ts
+++ b/src/app/services/feedback/FeedbackDAO.ts
@@ -16,6 +16,11 @@
 // this program. If not, see <http://www.gnu.org/licenses/>.
 //
 
+import {
+	Document,
+	DocumentQuery,
+} from 'mongoose';
+
 import Article from 'base/Article';
 import EndUser from 'base/EndUser';
 import Feedback from 'base/Feedback';
@@ -41,33 +46,33 @@ import emptyCheck from 'app/util/emptyCheck';
 
 // getByArticle
 
-export function getByArticle(
+export function getByArticle (
 	article : Article,
 	skip : number = defaultSkip,
 	limit : number = defaultLimit,
 	sort : Object = defaultSort
-) : Promise <Feedback[]> {
+) : Promise <Feedback[]>
+{
 	emptyCheck(article);
 
-	return wrapFind(
+	return wrapFind(populateFeedback(
 		FeedbackModel.find({
 			article: article.ID,
 		})
 		.sort(sort).skip(skip).limit(limit)
-		.populate('article')
-		.populate('enduser')
-	);
+	));
 }
 
 // getByArticleAuthor
 
-export function getByArticleAuthor(
+export function getByArticleAuthor (
 	author : User,
 	website? : Website,
 	skip : number = defaultSkip,
 	limit : number = defaultLimit,
 	sort : Object = defaultSort
-) : Promise <Feedback[]> {
+) : Promise <Feedback[]>
+{
 	emptyCheck(author);
 
 	const query : any = {
@@ -78,26 +83,49 @@ export function getByArticleAuthor(
 		query.website = website.ID;
 	}
 
-	return wrapFind(
+	return wrapFind(populateFeedback(
 		FeedbackModel.find(query)
 		.sort(sort).skip(skip).limit(limit)
-		.populate({
-			path: 'article',
-			populate: {
-				path: 'authors',
-			},
-		})
-		.populate('enduser')
-	);
+	));
+}
+
+// getRange, using internal populate
+
+export function getRange (
+	skip : number = defaultSkip,
+	limit : number = defaultLimit,
+	sort : Object = defaultSort
+) : Promise <Feedback[]>
+{
+	return wrapFind(populateFeedback(
+		FeedbackModel.find()
+		.sort(sort).skip(skip).limit(limit)
+	));
+}
+
+// Internal populate
+
+function populateFeedback <D extends Document> (
+	query : DocumentQuery <D[], D>
+) : DocumentQuery <D[], D>
+{
+	return query.populate({
+		path: 'article',
+		populate: {
+			path: 'authors',
+		},
+	})
+	.populate('enduser');
 }
 
 // save
 
-export function save(
+export function save (
 	article : Article,
 	enduser : EndUser,
 	items : FeedbackItem[]
-) : Promise <Feedback> {
+) : Promise <Feedback>
+{
 	emptyCheck(article, enduser, items);
 
 	// console.log('------------------------------------------------------------');

--- a/src/app/services/feedback/FeedbackService.live.ts
+++ b/src/app/services/feedback/FeedbackService.live.ts
@@ -31,6 +31,7 @@ import validateAndSave from './common/validateAndSave';
 import {
 	getByArticle,
 	getByArticleAuthor,
+	getRange,
 	save,
 } from './FeedbackDAO';
 
@@ -39,6 +40,7 @@ const service : FeedbackService
 		FeedbackModel, {
 			getByArticle,
 			getByArticleAuthor,
+			getRange,
 			save,
 			validateAndSave,
 		}

--- a/src/app/services/feedback/FeedbackService.mock.ts
+++ b/src/app/services/feedback/FeedbackService.mock.ts
@@ -31,6 +31,7 @@ import validateAndSave from './common/validateAndSave';
 import {
 	getByArticle,
 	getByArticleAuthor,
+	getRange,
 	save,
 } from './FeedbackDAO';
 
@@ -39,6 +40,7 @@ const service : FeedbackService
 		FeedbackModel, {
 			getByArticle,
 			getByArticleAuthor,
+			getRange,
 			save,
 			validateAndSave,
 		}

--- a/src/test/database/persisting-services/FeedbackServiceTests.ts
+++ b/src/test/database/persisting-services/FeedbackServiceTests.ts
@@ -16,6 +16,7 @@
 // this program. If not, see <http://www.gnu.org/licenses/>.
 //
 
+// import * as colors from 'ansicolors';
 import * as path from 'path';
 
 import { assert } from 'chai';
@@ -71,15 +72,10 @@ export default function(this: ISuiteCallbackContext) {
 	it('getByArticleAuthor()', () => {
 		return userService.get('Axel Egon Unterbichler')
 		.then(author => {
-			// console.error(colors.brightCyan(
-			// 	'--- author object to query ----------------------------------------------------'
-			// ));
-			// console.error(author);
-			// console.error('\n');
 			return feedbackService.getByArticleAuthor(author);
 		})
 		.then((results : Feedback[]) => {
-//			assert.lengthOf(results, 2);
+			assert.lengthOf(results, 2);
 			results.forEach((feedback, index) => {
 				// console.error(colors.brightYellow(
 				// 	`--- queried feedback #${index} -------------------------------------------------------`
@@ -105,8 +101,23 @@ const assertFeedbackObject = (f : Feedback) => {
 		assert.notProperty(f, prop);
 	});
 
+	// Test if "article" object was populated
+	assert.isObject(f.article);
+	[ 'authors', 'items', 'url', 'version' ].forEach(prop => {
+		assert.property(f.article, prop);
+	});
+
+	// Test if "article.authors" array was populated
+	assert.isArray(f.article.authors);
+	f.article.authors.forEach(author => {
+		assert.isObject(author);
+		[ 'email', 'name' ].forEach(prop => {
+			assert.property(author, prop);
+		});
+	});
+
 	assert.isObject(f.date);
 	assert.isObject(f.enduser);
+
 	assert.isArray(f.items);
-	assert.isArray(f.article.authors);
 };


### PR DESCRIPTION
Generic way to populate database result object through a common function. Not as generic as I wanted it to be, but the prototype-based variant where `populate()` is declared publicly on the service and can be directly invoked by `wrapFind()` is still in the laboratory.

Solves [RC-152](https://dbmedialab.atlassian.net/browse/RC-152)