### PR TITLE
Update sass-lint to latest version - fix linter problems

### DIFF
--- a/package.json
+++ b/package.json
@@ -156,7 +156,7 @@
 		"eslint-plugin-import": "^2.7.0",
 		"mocha": "3.5.3",
 		"nightwatch": "0.9.16",
-		"sass-lint": "1.10.2",
+		"sass-lint": "1.12.1",
 		"selenium-server-standalone-jar": "3.6.0",
 		"source-map-support": "^0.4.16",
 		"supports-color": "^4.2.1",

--- a/src/front/scss/layout/_home.scss
+++ b/src/front/scss/layout/_home.scss
@@ -308,7 +308,6 @@ p {
 		display: -ms-flexbox;
 		display: flex;
 		-webkit-align-items: flex-end;
-		-ms-align-items: flex-end;
 		align-items: flex-end;
 		-webkit-flex-flow: row;
 		-ms-flex-flow: row;

--- a/src/front/scss/pages/suggestion/_suggestion.scss
+++ b/src/front/scss/pages/suggestion/_suggestion.scss
@@ -42,7 +42,6 @@
 		display: -ms-flexbox;
 		display: flex;
 		-webkit-justify-content: flex-start;
-		-ms-justify-content: flex-start;
 		justify-content: flex-start;
 
 		textarea {


### PR DESCRIPTION
Finally fix them linter problems after Greenkeeper throwing the third update of this package since the build broke.

Closes #360 and #458