### PR TITLE
RC-214 Miss timestamps on documents in db created not from test env

### DIFF
--- a/src/app/db/plugins/TimestampPlugin.ts
+++ b/src/app/db/plugins/TimestampPlugin.ts
@@ -34,4 +34,10 @@ export default function(schema : Schema, options : any) {
 		}
 		next();
 	});
+
+	schema.pre('update', function () {
+		if (this.date === undefined || this.date.created === undefined) {
+			this.update({}, { $set: {'date.created': new Date()}});
+		}
+	});
 }

--- a/src/app/db/plugins/TimestampPlugin.ts
+++ b/src/app/db/plugins/TimestampPlugin.ts
@@ -36,7 +36,7 @@ export default function(schema : Schema, options : any) {
 	});
 
 	schema.pre('update', function () {
-		if (this.date === undefined || this.date.created === undefined) {
+		if (typeof this.date === 'undefined' || typeof this.date.created === 'undefined') {
 			this.update({}, { $set: {'date.created': new Date()}});
 		}
 	});

--- a/src/app/db/plugins/TimestampPlugin.ts
+++ b/src/app/db/plugins/TimestampPlugin.ts
@@ -36,8 +36,13 @@ export default function(schema : Schema, options : any) {
 	});
 
 	schema.pre('update', function () {
-		if (typeof this.date === 'undefined' || typeof this.date.created === 'undefined') {
-			this.update({}, { $set: {'date.created': new Date()}});
-		}
+		this.update({}, {
+			'$set': {
+				'date.modified': new Date(),
+			},
+			'$setOnInsert': {
+				'date.created': new Date(),
+			},
+		});
 	});
 }


### PR DESCRIPTION
### **Jira ticket**

[RC-214](https://dbmedialab.atlassian.net/browse/RC-214)

### **What is the problem?**

Only documents created while running tests have valid timestamps. While app works timestamps doesn't appear in new documents 

### **How the problem was fixed**

- Added pre-update hook into Timestamp plugin
- Hook configured to set timestamps to updated obj

### **What have been changed additionally**

- Nothing

### **Testing done**

Manually