### PR TITLE
Update TypeScript to 2.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -133,7 +133,7 @@
 		"@types/express-session": "^1.15.0",
 		"@types/ioredis": "^3.0.0",
 		"@types/kue": "^0.11.0",
-		"@types/lodash": "4.14.79",
+		"@types/lodash": "^4.14.103",
 		"@types/mocha": "^2.2.0",
 		"@types/mongodb": "^2.2.0",
 		"@types/mongoose": "^4.7.0",
@@ -168,7 +168,7 @@
 		"ts-node": "5.0.0",
 		"tsconfig-paths": "3.1.1",
 		"tslint": "5.9.1",
-		"typescript": "2.6.2",
+		"typescript": "2.7.2",
 		"webpack-bundle-analyzer": "^2.8.3"
 	},
 	"optionalDependencies": {

--- a/src/app/db/schemas/ArticleSchema.ts
+++ b/src/app/db/schemas/ArticleSchema.ts
@@ -17,9 +17,7 @@
 //
 
 import { Schema } from 'mongoose';
-
-import ArticleURL from 'base/ArticleURL';
-
+import { ArticleURL } from 'base/ArticleURL';
 import { objectReference } from 'app/db/common';
 import { ModelNames } from 'app/db/names';
 
@@ -27,7 +25,7 @@ const ArticleSchema : Schema = new Schema({
 	url: {
 		type: String,
 		required: true,
-		set: (url : ArticleURL) : string => url.href,
+		set: (url : string|ArticleURL) : string => url instanceof ArticleURL ? url.href : url,
 	},
 	version: {
 		type: String,

--- a/src/test/database/persisting-services/ArticleServiceTests.ts
+++ b/src/test/database/persisting-services/ArticleServiceTests.ts
@@ -147,8 +147,9 @@ const testGetRange = () => it('getRange()', () => {
 		articleService.getRange(0, testLimit),
 		// #3 skipping past the number of stored items should yield an empty result:
 		articleService.getRange(articleCount),
-	]).then((results : [Article[]]) => {
-		results.forEach(result => {
+	])
+	.spread((...ranges : Article[][]) => {
+		ranges.forEach(result => {
 			assert.isArray(result);
 			result.forEach(item => assertArticleObject(item));
 		});
@@ -159,7 +160,7 @@ const testGetRange = () => it('getRange()', () => {
 			0,
 		];
 
-		results.forEach((result : Article[], index : number) => {
+		ranges.forEach((result : Article[], index : number) => {
 			assert.lengthOf(
 				result,
 				lengthCheck[index],

--- a/src/test/database/persisting-services/EndUserServiceTests.ts
+++ b/src/test/database/persisting-services/EndUserServiceTests.ts
@@ -116,8 +116,9 @@ const testGetRange = () => it('getRange()', () => {
 		enduserService.getRange(0, testLimit),
 		// #3 skipping past the number of stored items should yield an empty result:
 		enduserService.getRange(userCount),
-	]).then((results : [EndUser[]]) => {
-		results.forEach(result => {
+	])
+	.spread((...ranges : EndUser[][]) => {
+		ranges.forEach(result => {
 			assert.isArray(result);
 			result.forEach(item => assertUserObject(item));
 		});
@@ -128,7 +129,7 @@ const testGetRange = () => it('getRange()', () => {
 			0,
 		];
 
-		results.forEach((result : EndUser[], index : number) => {
+		ranges.forEach((result : EndUser[], index : number) => {
 			assert.lengthOf(
 				result,
 				lengthCheck[index],

--- a/src/test/database/persisting-services/SuggestionServiceTests.ts
+++ b/src/test/database/persisting-services/SuggestionServiceTests.ts
@@ -95,8 +95,9 @@ const testGetRange = () => it('getRange()', () => {
 		suggestionService.getRange(0, testLimit),
 		// #3 skipping past the number of stored items should yield an empty result:
 		suggestionService.getRange(totalCount),
-	]).then((results : [Suggestion[]]) => {
-		results.forEach(result => assert.isArray(result));
+	])
+	.spread((...ranges : Suggestion[][]) => {
+		ranges.forEach(result => assert.isArray(result));
 
 		const lengthCheck = [
 			Math.min(totalCount, defaultLimit),
@@ -104,7 +105,7 @@ const testGetRange = () => it('getRange()', () => {
 			0,
 		];
 
-		results.forEach((result : Suggestion[], index : number) => {
+		ranges.forEach((result : Suggestion[], index : number) => {
 			assert.lengthOf(
 				result,
 				lengthCheck[index],

--- a/src/test/database/persisting-services/UserServiceTests.ts
+++ b/src/test/database/persisting-services/UserServiceTests.ts
@@ -111,6 +111,8 @@ const testGet = () => it('get()', () => {
 // userService.checkPassword()
 
 const testCheckPassword = () => it('checkPassword()', () => Promise.all([
+	userService.get('admin')
+		.then(u => userService.checkPassword(u, 'test')),
 	userService.get('Indiana Horst')
 		.then(u => userService.checkPassword(u, 'nix')),
 	userService.get('Ernst Eisenbichler')
@@ -118,10 +120,11 @@ const testCheckPassword = () => it('checkPassword()', () => Promise.all([
 	userService.get('Philipp Gröschler', 'philipp@sol.no')
 		.then(u => userService.checkPassword(u, 'freshguacamole')),
 ])
-.then((results: boolean[]) => {
-	assert.isFalse(results[0], 'Indiana Horst password is wrong');
-	assert.isTrue(results[1], 'Ernst Eisenbichler password is wrong');
-	assert.isFalse(results[2], 'Philipp Gröschler password is wrong');
+.spread((bAdmin : boolean, bHorst : boolean, bErnst : boolean, bPhilipp : boolean) => {
+	assert.isTrue(bAdmin, 'Admin password should be correct');
+	assert.isFalse(bHorst, 'Horst\'s password is wrong');
+	assert.isTrue(bErnst, 'Ernst\'s password should be correct');
+	assert.isFalse(bPhilipp, 'Philipp\'s password is wrong');
 }));
 
 // userService.getRange()
@@ -136,8 +139,9 @@ const testGetRange = () => it('getRange()', () => {
 		userService.getRange(0, testLimit),
 		// #3 skipping past the number of stored items should yield an empty result:
 		userService.getRange(userCount),
-	]).then((results: [User[]]) => {
-		results.forEach(result => {
+	])
+	.spread((...ranges : User[][]) => {
+		ranges.forEach(result => {
 			assert.isArray(result);
 			result.forEach(item => assertUserObject(item));
 		});
@@ -148,7 +152,7 @@ const testGetRange = () => it('getRange()', () => {
 			0,
 		];
 
-		results.forEach((result: User[], index: number) => {
+		ranges.forEach((result: User[], index: number) => {
 			assert.lengthOf(
 				result,
 				lengthCheck[index],

--- a/src/test/database/persisting-services/WebsiteServiceTests.ts
+++ b/src/test/database/persisting-services/WebsiteServiceTests.ts
@@ -109,8 +109,9 @@ const testGetRange = () => it('getRange()', () => {
 		websiteService.getRange(0, testLimit),
 		// #3 skipping past the number of stored items should yield an empty result:
 		websiteService.getRange(websiteCount),
-	]).then((results : [Website[]]) => {
-		results.forEach(result => {
+	])
+	.spread((...ranges : Website[][]) => {
+		ranges.forEach(result => {
 			assert.isArray(result);
 			result.forEach(item => assertWebsiteObject(item));
 		});
@@ -121,7 +122,7 @@ const testGetRange = () => it('getRange()', () => {
 			0,
 		];
 
-		results.forEach((result : Website[], index : number) => {
+		ranges.forEach((result : Website[], index : number) => {
 			assert.lengthOf(
 				result,
 				lengthCheck[index],


### PR DESCRIPTION
After VScode "Insiders Edition" has had a 2.7x version for a while now, it is finally stable and can be used. First fix necessary is changing some array-in-array constructs in the service tests, but with `Bluebird.spread()` this is way more nice anyway.

One new type error remains though:
```
src/app/services/website/WebsiteDAO.ts:72:2 - error TS2322: Type 'Partial<Pick<any, "name" | "parserClass" | "hosts" | "chiefEditors">>' is not assignable to type 'Pick<any, "name" | "parserClass" | "hosts" | "chiefEditors">'.
Property 'name' is optional in type 'Partial<Pick<any, "name" | "parserClass" | "hosts" | "chiefEditors">>' but required in type 'Pick<any, "name" | "parserClass" | "hosts" | "chiefEditors">'.
```
I have absolutely no clue how to fix this one and honestly I don't even want to. This is a case of generics shooting the developer in the foot. Rather rewrite this particular piece of code to _not_ use `lodash.pick` at all, this has to be done anyway in regard to necessary fixes in [RC-262](https://dbmedialab.atlassian.net/browse/RC-262) and some other ones that don't even have a ticket yet.