### PR TITLE
Better article update

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "reader-critics",
-	"version": "0.6.0",
+	"version": "0.6.1",
 	"license": "GPL-3.0",
 	"private": false,
 	"description": "Leserkritikk v2 (Reader Critics)",

--- a/src/app/db/common/wrapFind.ts
+++ b/src/app/db/common/wrapFind.ts
@@ -63,7 +63,7 @@ export function wrapFindOne <D extends Document, Z> (
 		result.exec()
 		.then((doc : D) => (doc === null) ? resolve(null) : doc.toObject())
 		.then((doc : null|Object) => {
-			if (!isObject(doc)) {
+			if (!(doc === null || isObject(doc))) {  // Explicit null-check here
 				return reject(new Error('result.exec() did not return a single object'));
 			}
 

--- a/src/app/queue/handlers/onPollArticleUpdate/notifyEnduserAboutUpdate.ts
+++ b/src/app/queue/handlers/onPollArticleUpdate/notifyEnduserAboutUpdate.ts
@@ -19,7 +19,6 @@
 import * as app from 'app/util/applib';
 
 import { isEmpty } from 'lodash';
-import { EmptyError } from 'app/util/errors';
 import { translate as __ } from 'app/services/localization';
 
 import MailTemplate from 'app/template/MailTemplate';
@@ -61,9 +60,7 @@ export function notifyEnduserAboutUpdate(
 		);
 
 		if (feedbacksWithUserData.length === 0) {
-			// Flow control through exception handling is a Bad Thing™ and I have
-			// to state that here again, because I'm repeating that pattern!
-			throw new EmptyError(null);
+			return;  // No feedbacks with user data/e-mail addresses -> do nothing
 		}
 
 		// Extract user e-mail addresses
@@ -71,13 +68,12 @@ export function notifyEnduserAboutUpdate(
 			feedbacksWithUserData.map((feedback : Feedback) => feedback.enduser.email),
 			layoutNotification(website, newRevision),
 			getMailSubject(website, newRevision),
-		]);
-	})
-
-	// Put everything together und shoot the mail
-	.spread((recipients : string[], html : string, subject : string) => (
-		SendGridMailer(recipients, subject, html)
-	));
+		])
+		// Put everything together und shoot the mail
+		.spread((recipients : string[], html : string, subject : string) => (
+			SendGridMailer(recipients, subject, html)
+		));
+	});
 }
 
 // E-mail layout


### PR DESCRIPTION
Polling article updates on the production system often leads to _"DuplicateError: E11000 duplicate key error collection"_ exceptions because the _article-object-to-be-written_ already exists in the database.

Mongo/Mongoose's `upsert()` doesn't fix the problem, because the next function in the chain expects the object ID of the "new revision" object. Now if this object does already exist, `upsert()` returns an object ID which points into nothing (more precisely, its numeric value is exactly +1 of the newest existing ID in the database).

So, in the end that means: do it manually. Check if the new object is already there, then use it, otherwise create it. Feels like doing MySQL back 15 years ago, when there was no _"insert ... on duplicate key update"_ syntax.

Final hint: due to the lack of transactions in MongoDB this is of course not an atomic operation. Chances of a collision should be fairly minimal though and it won't do any harm besides printing another _DuplicateError_ in the log.