### PR TITLE
This PR for Philipp to discuss about titles issue that was found in Abstract Parser

### DIFF
--- a/src/app/parser/AbstractIteratingParser.ts
+++ b/src/app/parser/AbstractIteratingParser.ts
@@ -22,6 +22,7 @@ import * as Cheerio from 'cheerio';
 import * as CheerioPlugin from './util/CheerioPlugin';
 
 import ArticleItem from 'base/ArticleItem';
+import ParsedContent from 'base/ParsedContent';
 
 import BaseIteratingItems from './BaseIteratingItems';
 import IteratingParserItem from './IteratingParserItem';
@@ -52,10 +53,13 @@ abstract class AbstractIteratingParser extends BaseIteratingItems {
 		});
 	}
 
-	protected parseContent() : Promise <ArticleItem[]> {
+	protected parseContent() : Promise <ParsedContent> {
 		this.parseElements();
 		this.iterateParsedElements();
-		return Promise.resolve(this.articleItems.content);
+		return Promise.resolve({
+			content: this.articleItems.content,
+			titles: this.articleItems.titles,
+		});
 	}
 
 	private parseElements() : void {

--- a/src/app/parser/AbstractParser.ts
+++ b/src/app/parser/AbstractParser.ts
@@ -22,6 +22,7 @@ import ArticleItem from 'base/ArticleItem';
 import ArticleItemType from 'base/ArticleItemType';
 import ArticleURL from 'base/ArticleURL';
 import Parser from 'base/Parser';
+import ParsedContent from 'base/ParsedContent';
 
 import BaseItems from './BaseItems';
 
@@ -63,6 +64,7 @@ abstract class AbstractParser extends BaseItems implements Parser {
 	 */
 	private parseArticle() : Promise <Article> {
 		let content : Array<ArticleItem>;
+		let titles : Array<ArticleItem>;
 
 		// First the handler that parses all the content is called. Each implementing
 		// parser has the freedom to extract *all* necessary items (like titles, etc)
@@ -71,13 +73,14 @@ abstract class AbstractParser extends BaseItems implements Parser {
 		// parser instance and just be returned/resolved in f.ex. parseTitles().
 		return this.parseContent()
 		.then(items => {
-			content = items;
+			content = items.content;
+			titles = items.titles;
 
 			return Promise.props({
 				version: this.parseVersion(),
 				authors: this.parseByline(),
 				titles: this.parseTitles(),
-				title: this.findTitle(items),
+				title: this.findTitle(titles),
 				featured: this.parseFeaturedImage(),
 			});
 		})
@@ -100,7 +103,7 @@ abstract class AbstractParser extends BaseItems implements Parser {
 	protected abstract parseByline() : Promise <ArticleAuthor[]>;
 	protected abstract parseTitles() : Promise <ArticleItem[]>;
 	protected abstract parseFeaturedImage() : Promise <ArticleItem[]>;
-	protected abstract parseContent() : Promise <ArticleItem[]>;
+	protected abstract parseContent() : Promise <ParsedContent>;
 
 	protected abstract parseTitleFromMetaData() : Promise <string>;
 

--- a/src/app/parser/impl/generic/GenericParser.ts
+++ b/src/app/parser/impl/generic/GenericParser.ts
@@ -21,6 +21,7 @@ import * as Cheerio from 'cheerio';
 import ArticleAuthor from 'base/ArticleAuthor';
 import ArticleItem from 'base/ArticleItem';
 import Parser from 'base/Parser';
+import ParsedContent from 'base/ParsedContent';
 
 import AbstractParser from '../../AbstractParser';
 
@@ -90,7 +91,7 @@ export default class GenericParser extends AbstractParser implements Parser {
 		return Promise.resolve(featured);
 	}
 
-	protected parseContent() : Promise <ArticleItem[]> {
+	protected parseContent() : Promise <ParsedContent> {
 		const items : ArticleItem[] = [];
 		const $elements = this.contentSelect(elementTags.join(','));
 
@@ -131,7 +132,7 @@ export default class GenericParser extends AbstractParser implements Parser {
 			}
 		}
 
-		return Promise.resolve(items);
+		return Promise.resolve({content: items, titles: items});
 	}
 
 }

--- a/src/base/ParsedContent.ts
+++ b/src/base/ParsedContent.ts
@@ -1,0 +1,26 @@
+//
+// LESERKRITIKK v2 (aka Reader Critics)
+// Copyright (C) 2017 DB Medialab/Aller Media AS, Oslo, Norway
+// https://github.com/dbmedialab/reader-critics/
+//
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the Free Software
+// Foundation, either version 3 of the License, or (at your option) any later
+// version.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+// FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along with
+// this program. If not, see <http://www.gnu.org/licenses/>.
+//
+
+import ArticleItem from 'base/ArticleItem';
+
+export interface ParsedContent {
+	content : Array <ArticleItem>
+	titles : Array <ArticleItem>
+}
+
+export default ParsedContent;


### PR DESCRIPTION
1. In the "AbstractParser" we have method "parseArticle". 

2. This method uses results of the method "parseContent" to form "Article".

3. Our interest here   -     this.findTitle(items).

4. Theses "items" are result of the method parseContent, which define(override) in the AbstractIteratingParser. And if you check these items you find out that titles are missing at all. And method "findTitle" after unsuccessful attempts to find title in the items, takes title from meta property. But if html does not contain title meta we get empty title and you can notice that only if you check db records or if you implement test and use data from API response.
Here I try to come up with it.
