### PR TITLE
Removed certificate.spec.acme from Certificate

### DIFF
--- a/kubefiles/certificate.yaml
+++ b/kubefiles/certificate.yaml
@@ -10,9 +10,3 @@ spec:
     kind: ClusterIssuer
   dnsNames:
     - {{ env "REPONAME" }}.{{ env "ENV" }}.medialaben.no
-  acme:
-    config:
-    - dns01:
-        provider: cf-dns
-      domains:
-        - {{ env "REPONAME" }}.{{ env "ENV" }}.medialaben.no


### PR DESCRIPTION
Based on upgrading guide from v0.7 to v0.8 of cert-manager.